### PR TITLE
Implement the logic for expiring sessions and stopping containers.

### DIFF
--- a/cmd/jujushell/config-jaas-insecure.yaml
+++ b/cmd/jujushell/config-jaas-insecure.yaml
@@ -3,4 +3,4 @@ juju-addrs: ["jimm.jujucharms.com:443"]
 log-level: debug
 image-name: "termserver"
 profiles: ["default"]
-session-timeout: 20
+session-timeout: 2

--- a/cmd/jujushell/config-jaas-insecure.yaml
+++ b/cmd/jujushell/config-jaas-insecure.yaml
@@ -3,3 +3,4 @@ juju-addrs: ["jimm.jujucharms.com:443"]
 log-level: debug
 image-name: "termserver"
 profiles: ["default"]
+session-timeout: 20

--- a/cmd/jujushell/config-jaas.yaml
+++ b/cmd/jujushell/config-jaas.yaml
@@ -3,6 +3,7 @@ juju-addrs: ["jimm.jujucharms.com:443"]
 log-level: debug
 image-name: "termserver"
 profiles: ["default"]
+session-timeout: 20
 tls-cert: |
   -----BEGIN CERTIFICATE-----
   MIIFezCCA2OgAwIBAgIJAKHprWndysgcMA0GCSqGSIb3DQEBCwUAMFQxCzAJBgNV

--- a/cmd/jujushell/main.go
+++ b/cmd/jujushell/main.go
@@ -12,6 +12,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"golang.org/x/crypto/acme/autocert"
 	"gopkg.in/errgo.v1"
@@ -49,11 +50,12 @@ func serve(configPath string) error {
 	defer log.Sync()
 	log.Infow("starting the server", "log level", conf.LogLevel, "port", conf.Port)
 	handler, err := jujushell.NewServer(jujushell.Params{
-		AllowedUsers: conf.AllowedUsers,
-		ImageName:    conf.ImageName,
-		JujuAddrs:    conf.JujuAddrs,
-		JujuCert:     conf.JujuCert,
-		Profiles:     conf.Profiles,
+		AllowedUsers:    conf.AllowedUsers,
+		ImageName:       conf.ImageName,
+		JujuAddrs:       conf.JujuAddrs,
+		JujuCert:        conf.JujuCert,
+		Profiles:        conf.Profiles,
+		SessionDuration: time.Duration(conf.SessionTimeout) * time.Minute,
 	})
 	if err != nil {
 		return errgo.Notef(err, "cannot create new server")

--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	Port int `yaml:"port"`
 	// Profiles holds the LXD profiles to use when launching containers.
 	Profiles []string `yaml:"profiles"`
-	// SessionTimeout holds the number of minutes of inactvity to wait before
+	// SessionTimeout holds the number of minutes of inactivity to wait before
 	// expiring a session and stopping the container instance. A zero value
 	// means that the session never expires.
 	SessionTimeout int `yaml:"session-timeout"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,22 +23,38 @@ var readTests = []struct {
 }{{
 	about: "valid config",
 	content: mustMarshalYAML(map[string]interface{}{
-		"allowed-users": []string{"who", "dalek"},
-		"image-name":    "myimage",
-		"juju-addrs":    []string{"1.2.3.4", "4.3.2.1"},
-		"juju-cert":     "my Juju cert",
-		"log-level":     "debug",
-		"port":          8047,
-		"profiles":      []string{"default", "termserver"},
+		"allowed-users":   []string{"who", "dalek"},
+		"image-name":      "myimage",
+		"juju-addrs":      []string{"1.2.3.4", "4.3.2.1"},
+		"juju-cert":       "my Juju cert",
+		"log-level":       "debug",
+		"port":            8047,
+		"profiles":        []string{"default", "termserver"},
+		"session-timeout": 42,
 	}),
 	expectedConfig: &config.Config{
-		AllowedUsers: []string{"who", "dalek"},
-		ImageName:    "myimage",
-		JujuAddrs:    []string{"1.2.3.4", "4.3.2.1"},
-		JujuCert:     "my Juju cert",
-		LogLevel:     zapcore.DebugLevel,
-		Port:         8047,
-		Profiles:     []string{"default", "termserver"},
+		AllowedUsers:   []string{"who", "dalek"},
+		ImageName:      "myimage",
+		JujuAddrs:      []string{"1.2.3.4", "4.3.2.1"},
+		JujuCert:       "my Juju cert",
+		LogLevel:       zapcore.DebugLevel,
+		Port:           8047,
+		Profiles:       []string{"default", "termserver"},
+		SessionTimeout: 42,
+	},
+}, {
+	about: "valid minimum config",
+	content: mustMarshalYAML(map[string]interface{}{
+		"image-name": "myimage",
+		"juju-addrs": []string{"1.2.3.4", "4.3.2.1"},
+		"port":       8047,
+		"profiles":   []string{"default", "termserver"},
+	}),
+	expectedConfig: &config.Config{
+		ImageName: "myimage",
+		JujuAddrs: []string{"1.2.3.4", "4.3.2.1"},
+		Port:      8047,
+		Profiles:  []string{"default", "termserver"},
 	},
 }, {
 	about: "valid jaas config",
@@ -79,8 +95,18 @@ var readTests = []struct {
 	content:       []byte("not a yaml"),
 	expectedError: `cannot parse ".*": yaml: unmarshal errors:\n.*`,
 }, {
-	about:         "invalid config",
+	about:         "invalid config: missing fields",
 	expectedError: `invalid configuration at ".*": missing fields: image-name, juju-addrs, port, profiles`,
+}, {
+	about: "invalid config: bad session timeout",
+	content: mustMarshalYAML(map[string]interface{}{
+		"image-name":      "myimage",
+		"juju-addrs":      []string{"1.2.3.4", "4.3.2.1"},
+		"port":            8047,
+		"profiles":        []string{"default", "termserver"},
+		"session-timeout": -1,
+	}),
+	expectedError: `invalid configuration at ".*": cannot specify a negative session timeout`,
 }, {
 	about: "invalid config for let's encrypt: keys specified",
 	content: mustMarshalYAML(map[string]interface{}{

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,5 +1,5 @@
 github.com/beorn7/perks	git	3ac7bf7a47d159a033b107610db8a1b6575507a4	2016-02-29T21:34:45Z
-github.com/frankban/quicktest	git	d3fb7fd00f4ce7dd021e4df347254ddfff2c87ea	2018-01-31T16:22:27Z
+github.com/frankban/quicktest	git	2c6a0d60c05cd2d970f356eee0623ddf1cd0d62d	2018-02-06T12:35:47Z
 github.com/golang/protobuf	git	4bd1920723d7b7c925de087aa32e2187708897f7	2016-11-09T07:27:36Z
 github.com/google/go-cmp	git	97aa668b73e764ccdd786bc3ccd2edffe621150e	2018-01-03T21:20:46Z
 github.com/gorilla/websocket	git	71fa72d4842364bc5f74185f4161e0099ea3624a	2017-10-13T02:08:58Z

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -26,7 +26,7 @@ var log = logging.Log()
 
 // Register registers the API handlers in the given mux.
 func Register(mux *http.ServeMux, juju JujuParams, lxd LXDParams, svc SvcParams) error {
-	reg, err := registry.New(svc.SessionDuration)
+	reg, err := registryNew(svc.SessionDuration)
 	if err != nil {
 		return errgo.Notef(err, "cannot create container registry")
 	}
@@ -198,4 +198,9 @@ func isUserAllowed(user string, allowed []string) bool {
 // jujuAuthenticate is defined as a variable for testing.
 var jujuAuthenticate = func(addrs []string, creds *juju.Credentials, cert string) (*juju.Info, error) {
 	return juju.Authenticate(addrs, creds, cert)
+}
+
+// registryNew is defined as a variable for testing.
+var registryNew = func(d time.Duration) (*registry.Registry, error) {
+	return registry.New(d)
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -84,7 +84,7 @@ func TestServeWebSocket(t *testing.T) {
 	for _, test := range serveWebSocketTests {
 		c.Run(test.about, func(c *qt.C) {
 			// Set up the WebSocket server.
-			server := httptest.NewServer(setupMux(test.addrs, test.allowedUsers))
+			server := httptest.NewServer(setupMux(c, test.addrs, test.allowedUsers))
 			defer server.Close()
 			patchJujuAuthenticate(c, test.authUser, test.authErr, test.addrs)
 
@@ -103,9 +103,9 @@ func TestServeWebSocket(t *testing.T) {
 }
 
 // setupMux creates and returns a mux with the API registered.
-func setupMux(addrs, allowedUsers []string) *http.ServeMux {
+func setupMux(c *qt.C, addrs, allowedUsers []string) *http.ServeMux {
 	mux := http.NewServeMux()
-	api.Register(mux, api.JujuParams{
+	err := api.Register(mux, api.JujuParams{
 		Addrs: addrs,
 		Cert:  "cert",
 	}, api.LXDParams{
@@ -114,6 +114,7 @@ func setupMux(addrs, allowedUsers []string) *http.ServeMux {
 	}, api.SvcParams{
 		AllowedUsers: allowedUsers,
 	})
+	c.Assert(err, qt.Equals, nil)
 	return mux
 }
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/gorilla/websocket"
@@ -18,6 +19,7 @@ import (
 	"github.com/juju/jujushell/internal/api"
 	"github.com/juju/jujushell/internal/juju"
 	"github.com/juju/jujushell/internal/logging"
+	"github.com/juju/jujushell/internal/registry"
 )
 
 var serveWebSocketTests = []struct {
@@ -105,6 +107,9 @@ func TestServeWebSocket(t *testing.T) {
 // setupMux creates and returns a mux with the API registered.
 func setupMux(c *qt.C, addrs, allowedUsers []string) *http.ServeMux {
 	mux := http.NewServeMux()
+	c.Patch(api.RegistryNew, func(d time.Duration) (*registry.Registry, error) {
+		return &registry.Registry{}, nil
+	})
 	err := api.Register(mux, api.JujuParams{
 		Addrs: addrs,
 		Cert:  "cert",

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/jujushell/apiparams"
 )
 
-const retries = 100
+const retries = 50
 
 func waitReady(url string) error {
 	var err error

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -54,7 +54,7 @@ func TestWaitReady(t *testing.T) {
 		handler: handler(c, mustMarshalJSON(apiparams.Response{
 			Code: apiparams.OK,
 		}), 1000),
-		expectedSleepCalls: 100,
+		expectedSleepCalls: 50,
 		expectedError:      "cannot get .*: EOF",
 	}, {
 		about:         "failure for non JSON response",

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -5,6 +5,7 @@ package api
 
 var (
 	JujuAuthenticate = &jujuAuthenticate
+	RegistryNew      = &registryNew
 	Sleep            = &sleep
 	WaitReady        = waitReady
 )

--- a/internal/api/status_test.go
+++ b/internal/api/status_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestStatusHandler(t *testing.T) {
 	c := qt.New(t)
+	defer c.Cleanup()
 	// Set up the WebSocket server.
 	server := httptest.NewServer(setupMux(c, []string{"1.2.3.4"}, nil))
 	defer server.Close()

--- a/internal/api/status_test.go
+++ b/internal/api/status_test.go
@@ -17,7 +17,7 @@ import (
 func TestStatusHandler(t *testing.T) {
 	c := qt.New(t)
 	// Set up the WebSocket server.
-	server := httptest.NewServer(setupMux([]string{"1.2.3.4"}, nil))
+	server := httptest.NewServer(setupMux(c, []string{"1.2.3.4"}, nil))
 	defer server.Close()
 
 	// Exercise the status handler.

--- a/internal/lxdutils/lxd_test.go
+++ b/internal/lxdutils/lxd_test.go
@@ -22,6 +22,7 @@ var ensureTests = []struct {
 	info   *juju.Info
 	creds  *juju.Credentials
 
+	expectedName  string
 	expectedAddr  string
 	expectedError string
 
@@ -283,6 +284,7 @@ var ensureTests = []struct {
 			"https://1.2.3.4/identity": macaroon.Slice{mustNewMacaroon("m1")},
 		},
 	},
+	expectedName: "ts-7b7074fca36fc89fb3f1e3c46d74f6ffe2477a09-rose",
 	expectedAddr: "1.2.3.6",
 	expectedCalls: [][]string{
 		call("All"),
@@ -311,6 +313,7 @@ var ensureTests = []struct {
 			"https://1.2.3.4/identity": macaroon.Slice{mustNewMacaroon("m1")},
 		},
 	},
+	expectedName: "ts-fc1565bb1f8fe145fda53955901546405e01a80b-cyberman-externa",
 	expectedAddr: "1.2.3.7",
 	expectedCalls: [][]string{
 		call("All"),
@@ -340,6 +343,7 @@ var ensureTests = []struct {
 			"https://1.2.3.4/identity": macaroon.Slice{mustNewMacaroon("m1")},
 		},
 	},
+	expectedName: "ts-3c91974643169203624b07aa9d35afb0564d6103-d-a-l-e-k",
 	expectedAddr: "1.2.3.4",
 	expectedCalls: [][]string{
 		call("All"),
@@ -358,9 +362,9 @@ var ensureTests = []struct {
 }}
 
 func TestEnsure(t *testing.T) {
+	c := qt.New(t)
 	for _, test := range ensureTests {
-		t.Run(test.about, func(t *testing.T) {
-			c := qt.New(t)
+		c.Run(test.about, func(c *qt.C) {
 			if test.info == nil {
 				test.info = &juju.Info{
 					User: "who",
@@ -378,12 +382,14 @@ func TestEnsure(t *testing.T) {
 				name: "ts-fc1565bb1f8fe145fda53955901546405e01a80b-cyberman-externa",
 				addr: "1.2.3.7",
 			}}
-			addr, err := lxdutils.Ensure(test.client, "termserver", []string{"default", "termserver"}, test.info, test.creds)
+			name, addr, err := lxdutils.Ensure(test.client, "termserver", []string{"default", "termserver"}, test.info, test.creds)
 			if test.expectedError != "" {
 				c.Assert(err, qt.ErrorMatches, test.expectedError)
+				c.Assert(name, qt.Equals, "")
 				c.Assert(addr, qt.Equals, "")
 			} else {
 				c.Assert(err, qt.Equals, nil)
+				c.Assert(name, qt.Equals, test.expectedName)
 				c.Assert(addr, qt.Equals, test.expectedAddr)
 			}
 			c.Assert(test.client.calls, qt.DeepEquals, test.expectedCalls)

--- a/internal/registry/export_test.go
+++ b/internal/registry/export_test.go
@@ -1,0 +1,9 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package registry
+
+var (
+	LXDutilsConnect = &lxdutilsConnect
+	TimeAfterFunc   = &timeAfterFunc
+)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,127 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package registry
+
+import (
+	"sync"
+	"time"
+
+	"gopkg.in/errgo.v1"
+
+	"github.com/juju/jujushell/internal/logging"
+	"github.com/juju/jujushell/internal/lxdclient"
+	"github.com/juju/jujushell/internal/lxdutils"
+)
+
+var log = logging.Log()
+
+// New creates and returns a new registry for active containers.
+func New(d time.Duration) (*Registry, error) {
+	client, err := lxdutilsConnect()
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot connect to LXD")
+	}
+	cs, err := client.All()
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot retrieve initial containers")
+	}
+	r := Registry{
+		d:          d,
+		containers: make(map[string]*ActiveContainer, len(cs)),
+	}
+	for _, c := range cs {
+		if c.Started() {
+			r.Get(c.Name())
+		}
+	}
+	return &r, nil
+}
+
+// Registry stores and keeps track of the currently active cobtainers. Use the
+// Get method on the registry to retrieve a stored container or add a new one.
+type Registry struct {
+	d          time.Duration
+	mu         sync.Mutex
+	containers map[string]*ActiveContainer
+}
+
+// Get returns the active container with the given name. The container is also
+// stored in the registry if not already known.
+func (r *Registry) Get(name string) *ActiveContainer {
+	log.Debugw("current active containers", "containers", r.containers)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	c := r.containers[name]
+	if c == nil {
+		c = &ActiveContainer{
+			name: name,
+			d:    r.d,
+		}
+		if r.d != 0 {
+			c.timer = timeAfterFunc(r.d, func() {
+				log.Debugw("stopping container for inactivity", "container", name)
+				if err := r.stop(name); err != nil {
+					log.Debugw("cannot stop container for inactivity", "container", name, "error", err.Error())
+				}
+			})
+		}
+		r.containers[name] = c
+	}
+	return c
+}
+
+// stop stops the container with the given name. It is usally called by a timer
+// after a certain amount of time without any activity on the container.
+func (r *Registry) stop(name string) error {
+	client, err := lxdutilsConnect()
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	c, err := client.Get(name)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	if !c.Started() {
+		return errgo.Newf("container %s is not started", name)
+	}
+	if err = c.Stop(); err != nil {
+		return errgo.Mask(err)
+	}
+	r.mu.Lock()
+	delete(r.containers, name)
+	r.mu.Unlock()
+	return nil
+}
+
+// ActiveContainer represents a container currently running.
+type ActiveContainer struct {
+	name  string
+	d     time.Duration
+	timer *time.Timer
+}
+
+// Name returns the name of the container.
+func (c *ActiveContainer) Name() string {
+	return c.name
+}
+
+// SetActive registers activity on the container.
+func (c *ActiveContainer) SetActive() {
+	if c.timer == nil {
+		return
+	}
+	if c.timer.Stop() {
+		c.timer.Reset(c.d)
+	}
+}
+
+// lxdutilsConnect is defined as a variable for testing.
+var lxdutilsConnect = func() (lxdclient.Client, error) {
+	return lxdutils.Connect()
+}
+
+// timeAfterFunc is defined as a variable for testing.
+var timeAfterFunc = func(d time.Duration, f func()) *time.Timer {
+	return time.AfterFunc(d, f)
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,226 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package registry_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/juju/jujushell/internal/lxdclient"
+	"github.com/juju/jujushell/internal/registry"
+)
+
+var newTests = []struct {
+	about                  string
+	client                 *client
+	clientError            string
+	expectedAfterFuncCalls int
+	expectedCalls          [][]string
+	expectedError          string
+}{{
+	about:         "error connecting to LXD",
+	clientError:   "bad wolf",
+	expectedError: "cannot connect to LXD: bad wolf",
+}, {
+	about: "error retrieving containers",
+	client: &client{
+		allError: errors.New("bad wolf"),
+	},
+	expectedCalls: [][]string{
+		call("All"),
+	},
+	expectedError: "cannot retrieve initial containers: bad wolf",
+}, {
+	about:  "success",
+	client: &client{},
+	expectedCalls: [][]string{
+		call("All"),
+	},
+}, {
+	about: "success with existing container instances",
+	client: &client{
+		allResult: []*container{
+			newContainer("c1", true, nil),
+			newContainer("c2", false, nil),
+			newContainer("c3", true, nil),
+		},
+	},
+	expectedAfterFuncCalls: 2,
+	expectedCalls: [][]string{
+		call("All"),
+		call("(c1).Started"),
+		call("(c1).Name"),
+		call("(c2).Started"),
+		call("(c3).Started"),
+		call("(c3).Name"),
+	},
+}}
+
+func TestNew(t *testing.T) {
+	c := qt.New(t)
+	for _, test := range newTests {
+		c.Run(test.about, func(c *qt.C) {
+			// Patch the LXD client connection.
+			c.Patch(registry.LXDutilsConnect, func() (lxdclient.Client, error) {
+				if test.clientError != "" {
+					return nil, errors.New(test.clientError)
+				}
+				return test.client, nil
+			})
+
+			// Patch the time.AfterFunc call.
+			var afterFuncCalls int
+			c.Patch(registry.TimeAfterFunc, func(d time.Duration, f func()) *time.Timer {
+				c.Assert(d, qt.Equals, duration)
+				afterFuncCalls++
+				return &time.Timer{}
+			})
+
+			// Run the test.
+			r, err := registry.New(duration)
+			if test.expectedError != "" {
+				c.Assert(err, qt.ErrorMatches, test.expectedError)
+				c.Assert(r, qt.IsNil)
+			} else {
+				c.Assert(err, qt.Equals, nil)
+				c.Assert(r, qt.Not(qt.IsNil))
+			}
+			c.Assert(afterFuncCalls, qt.Equals, test.expectedAfterFuncCalls)
+			if test.client != nil {
+				c.Assert(test.client.calls, qt.DeepEquals, test.expectedCalls)
+			}
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	c := qt.New(t)
+	defer c.Cleanup()
+
+	// Patch lxdutils.Connect and time.AfterFunc calls.
+	cl := client{
+		getResult: newContainer("my-container", true, nil),
+	}
+	c.Patch(registry.LXDutilsConnect, func() (lxdclient.Client, error) {
+		return &cl, nil
+	})
+	var timeoutFunc func()
+	c.Patch(registry.TimeAfterFunc, func(d time.Duration, f func()) *time.Timer {
+		timeoutFunc = f
+		return &time.Timer{}
+	})
+
+	//  Create a registry.
+	r, err := registry.New(duration)
+	c.Assert(err, qt.Equals, nil)
+
+	// Get an active container.
+	ac := r.Get("my-container")
+	c.Assert(ac.Name(), qt.Equals, "my-container")
+
+	// Ensure that running the timeout function stops the container.
+	c.Assert(timeoutFunc, qt.Not(qt.IsNil))
+	timeoutFunc()
+	c.Assert(cl.calls, qt.DeepEquals, [][]string{
+		call("All"),
+		call("Get", "my-container"),
+		call("(my-container).Started"),
+		call("(my-container).Stop"),
+	})
+
+	// Try again with a container already stopped.
+	cl.calls = nil
+	timeoutFunc()
+	c.Assert(cl.calls, qt.DeepEquals, [][]string{
+		call("Get", "my-container"),
+		call("(my-container).Started"),
+	})
+}
+
+// client implements lxdclient.Client for testing.
+type client struct {
+	lxdclient.Client
+
+	allResult []*container
+	allError  error
+
+	getResult *container
+	getError  error
+
+	calls [][]string
+}
+
+func (cl *client) register(name string, args ...string) {
+	cl.calls = append(cl.calls, call(name, args...))
+}
+
+func (cl *client) All() ([]lxdclient.Container, error) {
+	cl.register("All")
+	result := make([]lxdclient.Container, len(cl.allResult))
+	for i, container := range cl.allResult {
+		container.client = cl
+		result[i] = container
+	}
+	return result, cl.allError
+}
+
+func (cl *client) Get(name string) (lxdclient.Container, error) {
+	cl.register("Get", name)
+	if cl.getResult != nil {
+		cl.getResult.client = cl
+	}
+	return cl.getResult, cl.getError
+}
+
+// newContainer creates and returns a new testing container.
+func newContainer(name string, started bool, stopErr error) *container {
+	return &container{
+		name:    name,
+		started: started,
+		stopErr: stopErr,
+	}
+}
+
+// container implements lxdclient.Container for testing.
+type container struct {
+	lxdclient.Container
+
+	client *client
+
+	name    string
+	started bool
+	stopErr error
+}
+
+func (c *container) register(name string, args ...string) {
+	name = fmt.Sprintf("(%s).%s", c.name, name)
+	c.client.register(name, args...)
+}
+
+func (c *container) Name() string {
+	c.register("Name")
+	return c.name
+}
+
+func (c *container) Started() bool {
+	c.register("Started")
+	return c.started
+}
+
+func (c *container) Stop() error {
+	c.register("Stop")
+	c.started = false
+	return c.stopErr
+}
+
+func call(name string, args ...string) []string {
+	return append([]string{name}, args...)
+}
+
+// duration is the timeout duration used in tests.
+var duration = 42 * time.Second

--- a/internal/wsproxy/wsproxy_test.go
+++ b/internal/wsproxy/wsproxy_test.go
@@ -18,12 +18,13 @@ import (
 
 func TestCopy(t *testing.T) {
 	c := qt.New(t)
+
 	// Set up a target WebSocket server.
 	ping := httptest.NewServer(http.HandlerFunc(pingHandler))
 	defer ping.Close()
 
 	// Set up the WebSocket proxy that copies the messages back and forth.
-	proxy := httptest.NewServer(newProxyHandler(wsURL(ping.URL)))
+	proxy := httptest.NewServer(newProxyHandler(wsURL(ping.URL), nil))
 	defer proxy.Close()
 
 	// Connect to the proxy.
@@ -43,6 +44,43 @@ func TestCopy(t *testing.T) {
 	}
 	c.Assert(send("ping"), qt.Equals, "ping pong")
 	c.Assert(send("bad wolf"), qt.Equals, "bad wolf pong")
+}
+
+func TestNewConnWithHooks(t *testing.T) {
+	c := qt.New(t)
+
+	// Set up a target WebSocket server.
+	ping := httptest.NewServer(http.HandlerFunc(pingHandler))
+	defer ping.Close()
+
+	// Set up the WebSocket proxy that copies the messages back and forth, and
+	// register a hook in the connection.
+	var numMessages int
+	proxy := httptest.NewServer(newProxyHandler(wsURL(ping.URL), func(conn wsproxy.Conn) wsproxy.Conn {
+		return wsproxy.NewConnWithHooks(conn, func() {
+			numMessages++
+		})
+	}))
+	defer proxy.Close()
+
+	// Connect to the proxy.
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(proxy.URL), nil)
+	c.Assert(err, qt.Equals, nil)
+
+	// Send messages.
+	expectedNumMessages := 7
+	msg := jsonMessage{
+		Content: "ping",
+	}
+	for i := 0; i < expectedNumMessages; i++ {
+		err = conn.WriteJSON(msg)
+		c.Assert(err, qt.Equals, nil)
+		err = conn.ReadJSON(&msg)
+		c.Assert(err, qt.Equals, nil)
+	}
+
+	// The activity has been reported.
+	c.Assert(numMessages, qt.Equals, expectedNumMessages)
 }
 
 // pingHandler is a WebSocket handler responding to pings.
@@ -66,16 +104,20 @@ func pingHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 // newCopyHandler returns a WebSocket handler copying from the given WebSocket
-// server.
-func newProxyHandler(srvURL string) http.Handler {
+// server. The wrap function, if provided, is used to decorate the connection.
+func newProxyHandler(srvURL string, wrap func(wsproxy.Conn) wsproxy.Conn) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		conn1 := upgrade(w, req)
-		defer conn1.Close()
+		conn := upgrade(w, req)
+		defer conn.Close()
 		conn2, _, err := websocket.DefaultDialer.Dial(srvURL, nil)
 		if err != nil {
 			panic(err)
 		}
 		defer conn2.Close()
+		var conn1 wsproxy.Conn = conn
+		if wrap != nil {
+			conn1 = wrap(conn1)
+		}
 		if err := wsproxy.Copy(conn1, conn2); err != nil {
 			panic(err)
 		}

--- a/internal/wstransport/conn_test.go
+++ b/internal/wstransport/conn_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestConnError(t *testing.T) {
 	c := qt.New(t)
+
 	// Set up a WebSocket server that writes a JSON error response.
 	srv := httptest.NewServer(wsHandler(func(conn wstransport.Conn) {
 		badWolf := errors.New("bad wolf")
@@ -43,6 +44,7 @@ func TestConnError(t *testing.T) {
 
 func TestConnOK(t *testing.T) {
 	c := qt.New(t)
+
 	// Set up a WebSocket server that writes a JSON successful response.
 	srv := httptest.NewServer(wsHandler(func(conn wstransport.Conn) {
 		err := conn.OK("these %s the voyages", "are")

--- a/server.go
+++ b/server.go
@@ -5,6 +5,9 @@ package jujushell
 
 import (
 	"net/http"
+	"time"
+
+	"gopkg.in/errgo.v1"
 
 	"github.com/juju/jujushell/internal/api"
 )
@@ -12,15 +15,19 @@ import (
 // NewServer returns a new handler that handles juju shell requests.
 func NewServer(p Params) (http.Handler, error) {
 	mux := http.NewServeMux()
-	api.Register(mux, api.JujuParams{
+	err := api.Register(mux, api.JujuParams{
 		Addrs: p.JujuAddrs,
 		Cert:  p.JujuCert,
 	}, api.LXDParams{
 		ImageName: p.ImageName,
 		Profiles:  p.Profiles,
 	}, api.SvcParams{
-		AllowedUsers: p.AllowedUsers,
+		AllowedUsers:    p.AllowedUsers,
+		SessionDuration: p.SessionDuration,
 	})
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
 	return mux, nil
 }
 
@@ -36,4 +43,6 @@ type Params struct {
 	JujuCert string
 	// Profiles holds the LXD profiles to use when launching containers.
 	Profiles []string
+	// SessionDuration holds time duration before expiring container sessions.
+	SessionDuration time.Duration
 }


### PR DESCRIPTION
QA:
- run `jujushell cmd/jujushell/config-jaas-insecure.yaml` on an ubuntu machine with snapped LXD configured with a termserver profile (you can just copy over your default profile);
- run the local Juju GUI with `make run`;
- run guiproxy pointing the jujushell URL to your local machine. For instance: `guiproxy -env prod -flags terminal -config '"jujushellURL": "ws://dev.local:8047/ws/"'` (replace dev.local with the address or dns name of your local ubuntu where jujushell is running).
- visit the GUI, switch to a model, click on the shell button and wait for the session to be ready;
- do the same on 2 different tabs, so that you have 2 parallel shell sessions, let's call them session1 and session2;
- the session timeout in the config file you are running is 2 minutes, so type something in session 1 and wait for one minute, then type something on session2 and wait for another minute or more, the wait almost 2 minutes and type something again on session1: everything should work fine;
- but now wait for more than two minutes without any interaction with the shell, and you should see the connections to be dropped (the GUI windows should close but it doesn't, and that's a bug in the GUI: https://github.com/juju/juju-gui/issues/3461);
- `lxc list` should show the container to be stopped;
- close the GUI shell pane and open it 

