### PR TITLE
Add support for a configurable welcome message

### DIFF
--- a/apiparams/params.go
+++ b/apiparams/params.go
@@ -26,6 +26,8 @@ type Start struct {
 
 // Response holds a server response.
 type Response struct {
+	// Operation holds the originally requested operation.
+	Operation Operation `json:"operation"`
 	// Code is the response code.
 	Code ResponseCode `json:"code"`
 	// Message holds an optional response message.
@@ -35,14 +37,17 @@ type Response struct {
 // Operation is a server operation.
 type Operation string
 
+// OpLogin, OpStart and OpStatus hold API request operations.
 const (
-	OpLogin Operation = "login"
-	OpStart Operation = "start"
+	OpLogin  Operation = "login"
+	OpStart  Operation = "start"
+	OpStatus Operation = "status"
 )
 
 // ResponseCode is a server response code.
 type ResponseCode string
 
+// OK and Error hold the two possible response codes.
 const (
 	OK    ResponseCode = "ok"
 	Error ResponseCode = "error"

--- a/cmd/jujushell/config-jaas-insecure.yaml
+++ b/cmd/jujushell/config-jaas-insecure.yaml
@@ -4,4 +4,6 @@ log-level: debug
 image-name: "termserver"
 profiles: ["default"]
 session-timeout: 2
-welcome-message: Welcome to JAAS insecure jujushell!
+welcome-message: |
+  Welcome to JAAS insecure jujushell!
+  This is an example welcome message.

--- a/cmd/jujushell/config-jaas-insecure.yaml
+++ b/cmd/jujushell/config-jaas-insecure.yaml
@@ -4,3 +4,4 @@ log-level: debug
 image-name: "termserver"
 profiles: ["default"]
 session-timeout: 2
+welcome-message: Welcome to JAAS insecure jujushell!

--- a/cmd/jujushell/config-jaas.yaml
+++ b/cmd/jujushell/config-jaas.yaml
@@ -90,3 +90,4 @@ tls-key: |
   4sPdiZvu3TpcySGMiWBIBFwg1oKgif1oxONwKKqGsS1h+lJ2ejPQ2qQkdLTeKTnz
   43CbdD4VeC4VsMubOCjbT24bBdcU0CbjeA==
   -----END PRIVATE KEY-----
+welcome-message: Welcome to JAAS jujushell!

--- a/cmd/jujushell/config-jaas.yaml
+++ b/cmd/jujushell/config-jaas.yaml
@@ -90,4 +90,6 @@ tls-key: |
   4sPdiZvu3TpcySGMiWBIBFwg1oKgif1oxONwKKqGsS1h+lJ2ejPQ2qQkdLTeKTnz
   43CbdD4VeC4VsMubOCjbT24bBdcU0CbjeA==
   -----END PRIVATE KEY-----
-welcome-message: Welcome to JAAS jujushell!
+welcome-message: |
+  Welcome to JAAS jujushell!
+  This is an example welcome message.

--- a/cmd/jujushell/main.go
+++ b/cmd/jujushell/main.go
@@ -56,6 +56,7 @@ func serve(configPath string) error {
 		JujuCert:        conf.JujuCert,
 		Profiles:        conf.Profiles,
 		SessionDuration: time.Duration(conf.SessionTimeout) * time.Minute,
+		WelcomeMessage:  conf.WelcomeMessage,
 	})
 	if err != nil {
 		return errgo.Notef(err, "cannot create new server")

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,9 @@ type Config struct {
 	// TLSCert and TLSKey optionally hold TLS info for running the server.
 	TLSCert string `yaml:"tls-cert"`
 	TLSKey  string `yaml:"tls-key"`
+	// WelcomeMessage optionally holds a message to be displayed when users
+	// start the shell session.
+	WelcomeMessage string `yaml:"welcome-message"`
 }
 
 // Read reads the configuration options from a file at the given path.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,6 +31,7 @@ var readTests = []struct {
 		"port":            8047,
 		"profiles":        []string{"default", "termserver"},
 		"session-timeout": 42,
+		"welcome-message": "exterminate!",
 	}),
 	expectedConfig: &config.Config{
 		AllowedUsers:   []string{"who", "dalek"},
@@ -41,6 +42,7 @@ var readTests = []struct {
 		Port:           8047,
 		Profiles:       []string{"default", "termserver"},
 		SessionTimeout: 42,
+		WelcomeMessage: "exterminate!",
 	},
 }, {
 	about: "valid minimum config",

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -58,6 +58,8 @@ type SvcParams struct {
 	AllowedUsers []string
 	// SessionDuration holds time duration before expiring container sessions.
 	SessionDuration time.Duration
+	// WelcomeMessage optionally holds an initial welcome message for users.
+	WelcomeMessage string
 }
 
 // serveWebSocket handles WebSocket connections.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -82,7 +82,7 @@ func serveWebSocket(juju JujuParams, lxd LXDParams, svc SvcParams, reg *registry
 			return
 		}
 		log.Infow("user authenticated", "user", info.User, "uuid", info.ControllerUUID, "endpoints", info.Endpoints)
-		name, addr, err := handleStart(conn, lxd, info, creds)
+		name, addr, err := handleStart(conn, lxd, svc, info, creds)
 		if err != nil {
 			log.Infow("cannot start user session", "user", info.User, "err", err)
 			return
@@ -101,14 +101,14 @@ func serveWebSocket(juju JujuParams, lxd LXDParams, svc SvcParams, reg *registry
 // users is not empty, this function also checks that the user is allowed.
 // Example request/response:
 //     --> {"operation": "login", "username": "admin", "password": "secret"}
-//     <-- {"code": "ok", "message": "logged in as \"admin\""}
+//     <-- {"operation": "login", "code": "ok", "message": "logged in as \"admin\""}
 func handleLogin(conn wstransport.Conn, jujuAddrs []string, jujuCert string, allowedUsers []string) (info *juju.Info, creds *juju.Credentials, err error) {
 	var req apiparams.Login
 	if err = conn.ReadJSON(&req); err != nil {
-		return nil, nil, conn.Error(errgo.Mask(err))
+		return nil, nil, conn.Error(apiparams.OpLogin, errgo.Mask(err))
 	}
 	if req.Operation != apiparams.OpLogin {
-		return nil, nil, conn.Error(errgo.Newf("invalid operation %q: expected %q", req.Operation, apiparams.OpLogin))
+		return nil, nil, conn.Error(apiparams.OpLogin, errgo.Newf("invalid operation %q: expected %q", req.Operation, apiparams.OpLogin))
 	}
 	creds = &juju.Credentials{
 		Username:  req.Username,
@@ -118,44 +118,44 @@ func handleLogin(conn wstransport.Conn, jujuAddrs []string, jujuCert string, all
 	log.Debugw("authenticating to the controller", "addresses", jujuAddrs)
 	info, err = jujuAuthenticate(jujuAddrs, creds, jujuCert)
 	if err != nil {
-		return nil, nil, conn.Error(errgo.Notef(err, "cannot log into juju"))
+		return nil, nil, conn.Error(apiparams.OpLogin, errgo.Notef(err, "cannot log into juju"))
 	}
 	if !isUserAllowed(info.User, allowedUsers) {
-		return nil, nil, conn.Error(errgo.Newf("user %q is not allowed to access the service", info.User))
+		return nil, nil, conn.Error(apiparams.OpLogin, errgo.Newf("user %q is not allowed to access the service", info.User))
 	}
-	return info, creds, conn.OK("logged in as %q", info.User)
+	return info, creds, conn.OK(apiparams.OpLogin, "logged in as %q", info.User)
 }
 
 // handleStart ensures an LXD is available for the given username, by checking
 // whether one container is already started or, if not, creating one based on
 // the provided LXD parameters. Example request/response:
 //     --> {"operation": "start"}
-//     <-- {"code": "ok", "message": "session is ready"}
-func handleStart(conn wstransport.Conn, lxd LXDParams, info *juju.Info, creds *juju.Credentials) (name, addr string, err error) {
+//     <-- {"operation": "start", "code": "ok", "message": "session is ready"}
+func handleStart(conn wstransport.Conn, lxd LXDParams, svc SvcParams, info *juju.Info, creds *juju.Credentials) (name, addr string, err error) {
 	var req apiparams.Start
 	if err = conn.ReadJSON(&req); err != nil {
-		return "", "", conn.Error(errgo.Mask(err))
+		return "", "", conn.Error(apiparams.OpStart, errgo.Mask(err))
 	}
 	if req.Operation != apiparams.OpStart {
-		return "", "", conn.Error(errgo.Newf("invalid operation %q: expected %q", req.Operation, apiparams.OpStart))
+		return "", "", conn.Error(apiparams.OpStart, errgo.Newf("invalid operation %q: expected %q", req.Operation, apiparams.OpStart))
 	}
 	log.Debugw("connecting to the LXD server")
 	lxdclient, err := lxdutils.Connect()
 	if err != nil {
-		return "", "", conn.Error(errgo.Mask(err))
+		return "", "", conn.Error(apiparams.OpStart, errgo.Mask(err))
 	}
 	lxdclient = metrics.InstrumentLXDClient(lxdclient)
 	log.Debugw("setting up the LXD instance", "image", lxd.ImageName, "profiles", lxd.Profiles)
 	name, addr, err = lxdutils.Ensure(lxdclient, lxd.ImageName, lxd.Profiles, info, creds)
 	if err != nil {
-		return "", "", conn.Error(errgo.Mask(err))
+		return "", "", conn.Error(apiparams.OpStart, errgo.Mask(err))
 	}
 	url := fmt.Sprintf("http://%s:%d/status", addr, termserverPort)
 	log.Debugw("waiting for the internal shell service to be ready", "url", url)
 	if err = waitReady(url); err != nil {
-		return "", "", conn.Error(errgo.Mask(err))
+		return "", "", conn.Error(apiparams.OpStart, errgo.Mask(err))
 	}
-	return name, addr, conn.OK("session is ready")
+	return name, addr, conn.OK(apiparams.OpStart, svc.WelcomeMessage)
 }
 
 // handleSession proxies traffic from the client to the LXD instance with the

--- a/internal/api/status.go
+++ b/internal/api/status.go
@@ -15,7 +15,8 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 	enc := json.NewEncoder(w)
 	// Ignore errors here.
 	enc.Encode(apiparams.Response{
-		Code:    apiparams.OK,
-		Message: "server is ready",
+		Operation: apiparams.OpStatus,
+		Code:      apiparams.OK,
+		Message:   "server is ready",
 	})
 }

--- a/internal/api/status_test.go
+++ b/internal/api/status_test.go
@@ -31,6 +31,7 @@ func TestStatusHandler(t *testing.T) {
 	var r apiparams.Response
 	err = dec.Decode(&r)
 	c.Assert(err, qt.Equals, nil)
+	c.Assert(r.Operation, qt.Equals, apiparams.OpStatus)
 	c.Assert(r.Code, qt.Equals, apiparams.OK)
 	c.Assert(r.Message, qt.Equals, "server is ready")
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/juju/jujushell/apiparams"
 	"github.com/juju/jujushell/internal/lxdclient"
 	"github.com/juju/jujushell/internal/wstransport"
 )
@@ -70,8 +71,8 @@ type connection struct {
 }
 
 // Error implements wstransport.Conn.Error.
-func (conn *connection) Error(err error) error {
-	err = conn.Conn.Error(err)
+func (conn *connection) Error(op apiparams.Operation, err error) error {
+	err = conn.Conn.Error(op, err)
 	conn.errorsCount.WithLabelValues(err.Error()).Inc()
 	return err
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/juju/jujushell/apiparams"
 	"github.com/juju/jujushell/internal/lxdclient"
 	"github.com/juju/jujushell/internal/metrics"
 	"github.com/juju/jujushell/internal/wstransport"
@@ -73,7 +74,7 @@ func TestInstrumentWSConnection(t *testing.T) {
 		conn = metrics.InstrumentWSConnection(conn)
 		msg := errs[0]
 		errs = errs[1:]
-		conn.Error(errors.New(msg))
+		conn.Error(apiparams.OpStart, errors.New(msg))
 	}))
 	defer wsSrv.Close()
 

--- a/internal/wstransport/conn_test.go
+++ b/internal/wstransport/conn_test.go
@@ -23,7 +23,7 @@ func TestConnError(t *testing.T) {
 	// Set up a WebSocket server that writes a JSON error response.
 	srv := httptest.NewServer(wsHandler(func(conn wstransport.Conn) {
 		badWolf := errors.New("bad wolf")
-		err := conn.Error(badWolf)
+		err := conn.Error(apiparams.OpLogin, badWolf)
 		c.Assert(err, qt.Equals, badWolf)
 	}))
 	defer srv.Close()
@@ -37,8 +37,9 @@ func TestConnError(t *testing.T) {
 	err := conn.ReadJSON(&resp)
 	c.Assert(err, qt.Equals, nil)
 	c.Assert(resp, qt.DeepEquals, apiparams.Response{
-		Code:    apiparams.Error,
-		Message: "bad wolf",
+		Operation: apiparams.OpLogin,
+		Code:      apiparams.Error,
+		Message:   "bad wolf",
 	})
 }
 
@@ -47,7 +48,7 @@ func TestConnOK(t *testing.T) {
 
 	// Set up a WebSocket server that writes a JSON successful response.
 	srv := httptest.NewServer(wsHandler(func(conn wstransport.Conn) {
-		err := conn.OK("these %s the voyages", "are")
+		err := conn.OK(apiparams.OpStart, "these %s the voyages", "are")
 		c.Assert(err, qt.Equals, nil)
 	}))
 	defer srv.Close()
@@ -61,8 +62,9 @@ func TestConnOK(t *testing.T) {
 	err := conn.ReadJSON(&resp)
 	c.Assert(err, qt.Equals, nil)
 	c.Assert(resp, qt.DeepEquals, apiparams.Response{
-		Code:    apiparams.OK,
-		Message: "these are the voyages",
+		Operation: apiparams.OpStart,
+		Code:      apiparams.OK,
+		Message:   "these are the voyages",
 	})
 }
 

--- a/server.go
+++ b/server.go
@@ -24,6 +24,7 @@ func NewServer(p Params) (http.Handler, error) {
 	}, api.SvcParams{
 		AllowedUsers:    p.AllowedUsers,
 		SessionDuration: p.SessionDuration,
+		WelcomeMessage:  p.WelcomeMessage,
 	})
 	if err != nil {
 		return nil, errgo.Mask(err)
@@ -45,4 +46,6 @@ type Params struct {
 	Profiles []string
 	// SessionDuration holds time duration before expiring container sessions.
 	SessionDuration time.Duration
+	// WelcomeMessage optionally holds an initial welcome message for users.
+	WelcomeMessage string
 }


### PR DESCRIPTION
The message, if configured, is sent when the session is ready.
As part of this, the API has been slightly changed so that responses include the original request operation. This allows for more solid checks on clients, not relying on the optional response message which is purely informative. But this also means that the GUI must be updated accordingly (and I'll take care of that).